### PR TITLE
Feat : [posts] - 게시글 보기, 댓글 기능 구현

### DIFF
--- a/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
@@ -2,10 +2,14 @@ package com.fittogether.server.posts.controller;
 
 import com.fittogether.server.posts.domain.dto.PostDto;
 import com.fittogether.server.posts.domain.dto.PostForm;
+import com.fittogether.server.posts.domain.dto.PostInfo;
+import com.fittogether.server.posts.domain.dto.ReplyDto;
+import com.fittogether.server.posts.domain.dto.ReplyForm;
 import com.fittogether.server.posts.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -20,7 +24,7 @@ public class PostController {
   private final PostService postService;
 
   @PostMapping("/posts")
-  public ResponseEntity<PostDto> createPost(@RequestHeader(name = "Authorization") String token,
+  public ResponseEntity<PostDto> createPost(@RequestHeader(name = "X-AUTH-TOKEN") String token,
       @RequestBody PostForm postForm) {
 
     return ResponseEntity.ok(PostDto.from(
@@ -29,7 +33,7 @@ public class PostController {
   }
 
   @PutMapping("/posts/{postId}")
-  public ResponseEntity<PostDto> updatePost(@RequestHeader(name = "Authorization") String token,
+  public ResponseEntity<PostDto> updatePost(@RequestHeader(name = "X-AUTH-TOKEN") String token,
       @PathVariable Long postId,
       @RequestBody PostForm postForm) {
     return ResponseEntity.ok(PostDto.from(
@@ -37,10 +41,25 @@ public class PostController {
   }
   
   @DeleteMapping("/posts/{postId}")
-  public ResponseEntity<?> deletePost(@RequestHeader(name = "Authorization") String token,
+  public ResponseEntity<?> deletePost(@RequestHeader(name = "X-AUTH-TOKEN") String token,
       @PathVariable Long postId) {
     postService.deletePost(token, postId);
 
     return ResponseEntity.ok().body("게시글 삭제 완료");
+  }
+
+  @PostMapping("posts/{postId}/comment")
+  public ResponseEntity<ReplyDto> createReply(@RequestHeader(name = "X-AUTH-TOKEN") String token,
+      @PathVariable Long postId, @RequestBody ReplyForm replyForm) {
+    return ResponseEntity.ok(ReplyDto.from(
+        postService.createReply(token, postId, replyForm)));
+  }
+
+  @GetMapping("posts/{postId}")
+  public ResponseEntity<PostInfo> getPost(@PathVariable Long postId) {
+
+    return ResponseEntity.ok(
+        postService.getPostById(postId));
+
   }
 }

--- a/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
@@ -5,6 +5,7 @@ import com.fittogether.server.posts.domain.dto.PostForm;
 import com.fittogether.server.posts.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -33,6 +34,13 @@ public class PostController {
       @RequestBody PostForm postForm) {
     return ResponseEntity.ok(PostDto.from(
         postService.updatePost(token, postId, postForm)));
+  }
+  
+  @DeleteMapping("/posts/{postId}")
+  public ResponseEntity<?> deletePost(@RequestHeader(name = "Authorization") String token,
+      @PathVariable Long postId) {
+    postService.deletePost(token, postId);
 
+    return ResponseEntity.ok().body("게시글 삭제 완료");
   }
 }

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostDto.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostDto.java
@@ -1,15 +1,14 @@
 package com.fittogether.server.posts.domain.dto;
 
 import com.fittogether.server.posts.domain.model.Post;
+import com.fittogether.server.posts.type.Category;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -18,7 +17,7 @@ public class PostDto {
   private String title;
   private String description;
   private String image;
-  private String category;
+  private Category category;
   private boolean accessLevel;
   private LocalDateTime createdAt;
 

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostForm.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostForm.java
@@ -1,16 +1,13 @@
 package com.fittogether.server.posts.domain.dto;
 
-import com.fittogether.server.posts.domain.model.Hashtag;
 import com.fittogether.server.posts.type.Category;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -21,5 +18,5 @@ public class PostForm {
   private String image;
   private Category category;
   private boolean accessLevel;
-  private List<Hashtag> hashtag;
+  private List<String> hashtag;
 }

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostInfo.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostInfo.java
@@ -1,0 +1,44 @@
+package com.fittogether.server.posts.domain.dto;
+
+import com.fittogether.server.posts.domain.model.Post;
+import com.fittogether.server.posts.domain.model.Reply;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostInfo {
+
+  private Long userId;
+  private String category;
+  private String title;
+  private String description;
+  private String image;
+  private Long likes;
+  private Long watched;
+  private List<Reply> replyList;
+  private LocalDateTime createdAt;
+
+  public static PostInfo from(Post post, List<Reply> replyList) {
+
+    return PostInfo.builder()
+        .userId(post.getUser().getUserId())
+        .category(post.getCategory())
+        .title(post.getTitle())
+        .description(post.getDescription())
+        .image(post.getImage())
+//        .likes(post.getLikes())
+//        .watched(post.getWatched()+1)
+        .replyList(replyList)
+        .createdAt(post.getCreatedAt())
+        .build();
+  }
+}

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostInfo.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostInfo.java
@@ -2,29 +2,29 @@ package com.fittogether.server.posts.domain.dto;
 
 import com.fittogether.server.posts.domain.model.Post;
 import com.fittogether.server.posts.domain.model.Reply;
+import com.fittogether.server.posts.type.Category;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class PostInfo {
 
   private Long userId;
-  private String category;
+  private Category category;
   private String title;
   private String description;
   private String image;
   private Long likes;
   private Long watched;
-  private List<Reply> replyList;
+  private List<ReplyDto> replyList;
   private LocalDateTime createdAt;
 
   public static PostInfo from(Post post, List<Reply> replyList) {
@@ -35,9 +35,9 @@ public class PostInfo {
         .title(post.getTitle())
         .description(post.getDescription())
         .image(post.getImage())
-//        .likes(post.getLikes())
-//        .watched(post.getWatched()+1)
-        .replyList(replyList)
+        .likes(post.getLikes())
+        .watched(post.getWatched())
+        .replyList(replyList.stream().map(ReplyDto::from).collect(Collectors.toList()))
         .createdAt(post.getCreatedAt())
         .build();
   }

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyDto.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyDto.java
@@ -1,0 +1,33 @@
+package com.fittogether.server.posts.domain.dto;
+
+import com.fittogether.server.posts.domain.model.Reply;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReplyDto {
+  private String comment;
+  private Long likes;
+  private LocalDateTime createdAt;
+  private LocalDateTime modifiedAt;
+  private String userNickname;
+  private Long postId;
+
+  public static ReplyDto from(Reply reply) {
+    return ReplyDto.builder()
+        .comment(reply.getComment())
+        .likes(reply.getLikes())
+        .createdAt(LocalDateTime.now())
+        .userNickname(reply.getUser().getNickname())
+        .postId(reply.getPost().getId())
+        .build();
+  }
+}

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyDto.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyDto.java
@@ -6,16 +6,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class ReplyDto {
   private String comment;
-  private Long likes;
   private LocalDateTime createdAt;
   private LocalDateTime modifiedAt;
   private String userNickname;
@@ -24,7 +21,6 @@ public class ReplyDto {
   public static ReplyDto from(Reply reply) {
     return ReplyDto.builder()
         .comment(reply.getComment())
-        .likes(reply.getLikes())
         .createdAt(LocalDateTime.now())
         .userNickname(reply.getUser().getNickname())
         .postId(reply.getPost().getId())

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyForm.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyForm.java
@@ -1,0 +1,17 @@
+package com.fittogether.server.posts.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReplyForm {
+  private String comment;
+  private boolean likes;
+}

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyForm.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyForm.java
@@ -4,14 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class ReplyForm {
   private String comment;
-  private boolean likes;
 }

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyInfo.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyInfo.java
@@ -1,0 +1,20 @@
+package com.fittogether.server.posts.domain.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReplyInfo {
+  private Long replyId;
+  private String comment;
+  private Long likes;
+  private LocalDateTime createdAt;
+}

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyInfo.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyInfo.java
@@ -5,16 +5,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class ReplyInfo {
   private Long replyId;
   private String comment;
-  private Long likes;
   private LocalDateTime createdAt;
 }

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Post.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Post.java
@@ -33,6 +33,9 @@ public class Post {
   @JoinColumn(name = "user_id")
   private User user;
 
+  @JoinColumn(name = "user_id")
+  private Long userId;
+
   private String title;
   private String description;
   private String image;

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Post.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Post.java
@@ -28,7 +28,7 @@ public class Post {
 
   @ManyToOne
   @JoinColumn(name = "user_id")
-  private User userId;
+  private User user;
 
   private String title;
   private String description;

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Post.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Post.java
@@ -1,8 +1,11 @@
 package com.fittogether.server.posts.domain.model;
 
+import com.fittogether.server.posts.type.Category;
 import com.fittogether.server.user.domain.model.User;
 import java.time.LocalDateTime;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -33,7 +36,9 @@ public class Post {
   private String title;
   private String description;
   private String image;
-  private String category;
+
+  @Enumerated(value = EnumType.STRING)
+  private Category category;
   private Long likes;
   private Long watched;
   private boolean accessLevel;

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Reply.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Reply.java
@@ -1,0 +1,39 @@
+package com.fittogether.server.posts.domain.model;
+
+import com.fittogether.server.user.domain.model.User;
+import java.time.LocalDateTime;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Reply {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  private String comment;
+  private Long likes;
+  private LocalDateTime createdAt;
+  private LocalDateTime modifiedAt;
+
+  @ManyToOne
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  @ManyToOne
+  @JoinColumn(name = "post_id")
+  private Post post;
+}

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Reply.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Reply.java
@@ -25,7 +25,6 @@ public class Reply {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
   private String comment;
-  private Long likes;
   private LocalDateTime createdAt;
   private LocalDateTime modifiedAt;
 

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Reply.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Reply.java
@@ -26,7 +26,6 @@ public class Reply {
   private Long id;
   private String comment;
   private LocalDateTime createdAt;
-  private LocalDateTime modifiedAt;
 
   @ManyToOne
   @JoinColumn(name = "user_id")

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/repository/ReplyRepository.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/repository/ReplyRepository.java
@@ -1,0 +1,9 @@
+package com.fittogether.server.posts.domain.repository;
+
+import com.fittogether.server.posts.domain.model.Reply;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReplyRepository extends JpaRepository<Reply, Long> {
+  List<Reply> findByPostId(Long postId);
+}

--- a/server/posts/src/main/java/com/fittogether/server/posts/exception/ErrorCode.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/exception/ErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 @Getter
 public enum ErrorCode {
-    NOT_FOUND_POST(HttpStatus.BAD_REQUEST, "게시글을 찾을 수 없습니다.");
+    NOT_FOUND_POST(HttpStatus.BAD_REQUEST, "게시글을 찾을 수 없습니다."),
+    NO_PERMISSION_TO_VIEW_POST(HttpStatus.BAD_REQUEST, "게시글을 볼 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String detail;

--- a/server/posts/src/main/java/com/fittogether/server/posts/service/PostService.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/service/PostService.java
@@ -154,7 +154,6 @@ public class PostService {
     postRepository.delete(post);
   }
 
-  @Transactional
   public PostInfo getPostById(Long postId) {
 
     Post post = postRepository.findById(postId)

--- a/server/posts/src/test/http/posts.http
+++ b/server/posts/src/test/http/posts.http
@@ -1,6 +1,7 @@
 ### create post
 POST http://localhost:8080/posts
 Content-Type: application/json
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzTTRPKzhMZTlwNHpncUlhbUhQekZnPT0iLCJqdGkiOiJjYTlYUzFwT1RRcHNubFJaYzNncHhnPT0iLCJpYXQiOjE2OTAzNzU2NjUsImV4cCI6MTY5MDQ2MjA2NX0.6Eghoho8nIb4msK_zVSc_9TprrB91NGJ0BsF-BZ1x2o
 
 {
   "title": "제목",
@@ -15,8 +16,9 @@ Content-Type: application/json
 }
 
 ### update post
-PUT http://localhost:8080/posts/8
+PUT http://localhost:8080/posts/9
 Content-Type: application/json
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzTTRPKzhMZTlwNHpncUlhbUhQekZnPT0iLCJqdGkiOiJjYTlYUzFwT1RRcHNubFJaYzNncHhnPT0iLCJpYXQiOjE2OTAzNzU2NjUsImV4cCI6MTY5MDQ2MjA2NX0.6Eghoho8nIb4msK_zVSc_9TprrB91NGJ0BsF-BZ1x2o
 
 {
   "title": "제목2",
@@ -25,7 +27,12 @@ Content-Type: application/json
   "category": "RUNNING",
   "accessLevel": true,
   "hashtag": [
-    {"keyword": "운동" },
-    {"keyword": "클라이밍" }
+    {"keyword": "러닝" },
+    {"keyword": "등산" }
   ]
 }
+
+### delete post
+DELETE http://localhost:8080/posts/9
+Content-Type: application/json
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzTTRPKzhMZTlwNHpncUlhbUhQekZnPT0iLCJqdGkiOiJjYTlYUzFwT1RRcHNubFJaYzNncHhnPT0iLCJpYXQiOjE2OTAzNzU2NjUsImV4cCI6MTY5MDQ2MjA2NX0.6Eghoho8nIb4msK_zVSc_9TprrB91NGJ0BsF-BZ1x2o

--- a/server/posts/src/test/http/posts.http
+++ b/server/posts/src/test/http/posts.http
@@ -1,14 +1,14 @@
 ### create post
 POST http://localhost:8080/posts
 Content-Type: application/json
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzTTRPKzhMZTlwNHpncUlhbUhQekZnPT0iLCJqdGkiOiJjYTlYUzFwT1RRcHNubFJaYzNncHhnPT0iLCJpYXQiOjE2OTAzNzU2NjUsImV4cCI6MTY5MDQ2MjA2NX0.6Eghoho8nIb4msK_zVSc_9TprrB91NGJ0BsF-BZ1x2o
+X-AUTH-TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzTTRPKzhMZTlwNHpncUlhbUhQekZnPT0iLCJqdGkiOiJjYTlYUzFwT1RRcHNubFJaYzNncHhnPT0iLCJpYXQiOjE2OTAzNzU2NjUsImV4cCI6MTY5MDQ2MjA2NX0.6Eghoho8nIb4msK_zVSc_9TprrB91NGJ0BsF-BZ1x2o
 
 {
   "title": "제목",
   "description": "내용",
   "image": "",
   "category": "CLIMBING",
-  "accessLevel": true,
+  "accessLevel": false,
   "hashtag": [
     {"keyword": "오운완"},
     {"keyword": "운동"}
@@ -18,7 +18,7 @@ Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzTTRPKzhMZTlwNHpncUlhbUhQekZnPT0i
 ### update post
 PUT http://localhost:8080/posts/9
 Content-Type: application/json
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzTTRPKzhMZTlwNHpncUlhbUhQekZnPT0iLCJqdGkiOiJjYTlYUzFwT1RRcHNubFJaYzNncHhnPT0iLCJpYXQiOjE2OTAzNzU2NjUsImV4cCI6MTY5MDQ2MjA2NX0.6Eghoho8nIb4msK_zVSc_9TprrB91NGJ0BsF-BZ1x2o
+X-AUTH-TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzTTRPKzhMZTlwNHpncUlhbUhQekZnPT0iLCJqdGkiOiJjYTlYUzFwT1RRcHNubFJaYzNncHhnPT0iLCJpYXQiOjE2OTAzNzU2NjUsImV4cCI6MTY5MDQ2MjA2NX0.6Eghoho8nIb4msK_zVSc_9TprrB91NGJ0BsF-BZ1x2o
 
 {
   "title": "제목2",
@@ -35,4 +35,18 @@ Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzTTRPKzhMZTlwNHpncUlhbUhQekZnPT0i
 ### delete post
 DELETE http://localhost:8080/posts/9
 Content-Type: application/json
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzTTRPKzhMZTlwNHpncUlhbUhQekZnPT0iLCJqdGkiOiJjYTlYUzFwT1RRcHNubFJaYzNncHhnPT0iLCJpYXQiOjE2OTAzNzU2NjUsImV4cCI6MTY5MDQ2MjA2NX0.6Eghoho8nIb4msK_zVSc_9TprrB91NGJ0BsF-BZ1x2o
+X-AUTH-TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzTTRPKzhMZTlwNHpncUlhbUhQekZnPT0iLCJqdGkiOiJjYTlYUzFwT1RRcHNubFJaYzNncHhnPT0iLCJpYXQiOjE2OTAzNzU2NjUsImV4cCI6MTY5MDQ2MjA2NX0.6Eghoho8nIb4msK_zVSc_9TprrB91NGJ0BsF-BZ1x2o
+
+### create reply
+POST http://localhost:8080/posts/10/comment
+Content-Type: application/json
+X-AUTH-TOKEN: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzTTRPKzhMZTlwNHpncUlhbUhQekZnPT0iLCJqdGkiOiJjYTlYUzFwT1RRcHNubFJaYzNncHhnPT0iLCJpYXQiOjE2OTAzNzU2NjUsImV4cCI6MTY5MDQ2MjA2NX0.6Eghoho8nIb4msK_zVSc_9TprrB91NGJ0BsF-BZ1x2o
+
+{
+  "comment": "반갑습니다."
+}
+
+### click post
+GET http://localhost:8080/posts/11
+Content-Type: application/json
+


### PR DESCRIPTION
- 게시글 삭제 ( @DeleteMapping("/posts/{postId}") )
토큰 검증을 하고 연결되어있는 postHashtag의 id(게시글에 사용된 해시태그)를 먼저 제거한 뒤 게시글을 삭제합니다.

- 게시글 보기 ( @GetMapping("posts/{postId}") )
isAccessLevel이 false인 경우 이웃만 확인할 수 있지만 이건 추후 dm기능과 연결 뒤에 구현 예정으로 일단은 권한이 없다고 예외를 던지는걸로 작성했습니다.
replyRepository에서 findByPostId를 통해 댓글 리스트를 가져오도록 했습니다.

- 댓글 작성 ( @PostMapping("posts/{postId}/comment") )
user와 post 각각 findById를 통해 관계 entity를 받아와 Builder를 통해 Reply 엔터티에 맵핑하고 저장합니다.

@RequestHeader의 name "X-AUTH-TOKEN"으로 통일,
form이나 dto단에서 entity자체를 사용하지 않도록 변경,
Entity 클래스에 enum타입 그대로 넣고 DB저장시에만
@Enumerated(value = EnumType.STRING) 를 통해 스트링으로 저장되도록함