### PR TITLE
feat:[dm] - 메이트 수락

### DIFF
--- a/server/dm/build.gradle
+++ b/server/dm/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'javax.validation:validation-api:2.0.1.Final' // 사용하는 버전에 맞게 변경하세요
+    implementation 'javax.validation:validation-api:2.0.1.Final'
 
     //implementation project(':domain')
 

--- a/server/dm/src/main/java/com/fittogether/server/dm/domain/dto/ChatRoomDto.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/domain/dto/ChatRoomDto.java
@@ -15,14 +15,10 @@ public class ChatRoomDto {
     private LocalDateTime chatRoomDt;// 채팅방 생성 시간
 
     public ChatRoomDto(LocalDateTime now) {
+        this.chatRoomDt=now;
     }
 
 
-    public static ChatRoomDto from(ChatRoom chatRoom){
-        return ChatRoomDto.builder()
-                .chatRoomId(chatRoom.getChatRoomId())
-                .chatRoomDt(chatRoom.getChatRoomDt())
-                .build();
-    }
+
 
 }

--- a/server/dm/src/main/java/com/fittogether/server/dm/domain/dto/ChattingDto.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/domain/dto/ChattingDto.java
@@ -1,7 +1,6 @@
 package com.fittogether.server.dm.domain.dto;
 
 import com.fittogether.server.dm.domain.entity.ChatRoom;
-import com.fittogether.server.dm.domain.entity.Chatting;
 import com.fittogether.server.dm.domain.entity.Request;
 import lombok.*;
 
@@ -14,15 +13,18 @@ public class ChattingDto {
 
     private Long senderId; // 매칭 요쳥하는 유저 아이디 값
     private Long receiverId; //메칭 요청받는 유저 아이디 값
+
+    private boolean isMatched; // 매칭 수락여부
     private Long roomId; //  채팅방 아이디 값 (ChatRoom 채팅방아이디 값 참조)
 
 
 
 
-    public static ChattingDto requestFrom(Request request , ChatRoom chatRoom){
+    public static ChattingDto from(Request request , ChatRoom chatRoom){
         return ChattingDto.builder()
                 .senderId(request.getSenderId())
                 .receiverId(request.getReceiverId())
+                .isMatched(request.isAccepted())
                 .roomId(chatRoom.getChatRoomId())
                 .build();
     }

--- a/server/dm/src/main/java/com/fittogether/server/dm/domain/dto/RequestDto.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/domain/dto/RequestDto.java
@@ -1,0 +1,30 @@
+package com.fittogether.server.dm.domain.dto;
+
+import com.fittogether.server.dm.domain.entity.Request;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@ToString
+@AllArgsConstructor
+@Builder
+public class RequestDto {
+
+
+    private Long senderId; //매칭 요청하는 유저 아이디 값
+
+    private Long receiverId; // 매창 요청받는 유저 아이디 값
+
+    private boolean isAccept; //매칭 수락여부
+
+
+    public static RequestDto from(Request request){
+        return RequestDto.builder()
+                .senderId(request.getSenderId())
+                .receiverId(request.getReceiverId())
+                .isAccept(request.isAccepted())
+                .build();
+    }
+
+
+}

--- a/server/dm/src/main/java/com/fittogether/server/dm/domain/dto/RequestForm.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/domain/dto/RequestForm.java
@@ -16,6 +16,4 @@ public class RequestForm {
 
 
 
-
-
 }

--- a/server/dm/src/main/java/com/fittogether/server/dm/domain/dto/RequestForm.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/domain/dto/RequestForm.java
@@ -8,12 +8,8 @@ import lombok.*;
 @Builder
 
 public class RequestForm {
-
-
-
     private Long senderId; //메이트 요청 보낸 사람의 id값
     private Long receiverId; //메이트 요청을 받는 유저의 id값
-
 
 
 }

--- a/server/dm/src/main/java/com/fittogether/server/dm/domain/entity/ChatRoom.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/domain/entity/ChatRoom.java
@@ -24,7 +24,6 @@ public class ChatRoom {
     private LocalDateTime chatRoomDt;
 
 
-    public ChatRoom(LocalDateTime now) {
-    }
+
 
 }

--- a/server/dm/src/main/java/com/fittogether/server/dm/domain/entity/Chatting.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/domain/entity/Chatting.java
@@ -27,4 +27,5 @@ public class Chatting {
 
 
 
+
 }

--- a/server/dm/src/main/java/com/fittogether/server/dm/domain/entity/Request.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/domain/entity/Request.java
@@ -27,12 +27,10 @@ public class Request {
 
 
     public static Request from(RequestForm requestForm){
-
                Request request = Request.builder()
                 .senderId(requestForm.getSenderId())
                 .receiverId(requestForm.getReceiverId())
                 .build();
-
 
         return request;
 

--- a/server/dm/src/main/java/com/fittogether/server/dm/domain/repository/ChatRoomRepository.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/domain/repository/ChatRoomRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ChatRoomRepository extends JpaRepository<ChatRoom,Long> {
 
 
+
 }

--- a/server/dm/src/main/java/com/fittogether/server/dm/domain/repository/ChattingRepository.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/domain/repository/ChattingRepository.java
@@ -1,10 +1,14 @@
 package com.fittogether.server.dm.domain.repository;
 
-import com.fittogether.server.dm.domain.entity.Request;
+import com.fittogether.server.dm.domain.entity.Chatting;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RequestRepository extends JpaRepository<Request,Long> {
-    Request findAllBySenderId(Long senderId);
+public interface ChattingRepository extends JpaRepository<Chatting,Long> {
+
+
+
+
+
 }

--- a/server/dm/src/main/java/com/fittogether/server/dm/domain/repository/RequestRepository.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/domain/repository/RequestRepository.java
@@ -1,13 +1,10 @@
 package com.fittogether.server.dm.domain.repository;
 
 import com.fittogether.server.dm.domain.entity.Request;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RequestRepository extends JpaRepository<Request,Long> {
-
-
 
 }

--- a/server/dm/src/main/java/com/fittogether/server/dm/exception/MateErrorCode.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/exception/MateErrorCode.java
@@ -1,4 +1,0 @@
-package com.fittogether.server.dm.exception;
-
-public class MateErrorCode {
-}

--- a/server/dm/src/main/java/com/fittogether/server/dm/exception/MateErrorCode.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/exception/MateErrorCode.java
@@ -1,0 +1,4 @@
+package com.fittogether.server.dm.exception;
+
+public class MateErrorCode {
+}

--- a/server/dm/src/main/java/com/fittogether/server/dm/exception/MateExceptionCode.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/exception/MateExceptionCode.java
@@ -1,0 +1,9 @@
+package com.fittogether.server.dm.exception;
+
+public class MateExceptionCode extends RuntimeException {
+
+    public MateExceptionCode(String message) {
+        super(message);
+    }
+
+}

--- a/server/dm/src/main/java/com/fittogether/server/dm/mate/controller/MateController.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/mate/controller/MateController.java
@@ -10,10 +10,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RestController
-public class mateController {
+public class MateController {
     private final MateService mateService;
 
-    public mateController(MateService mateService) {
+    public MateController(MateService mateService) {
         this.mateService = mateService;
     }
 

--- a/server/dm/src/main/java/com/fittogether/server/dm/mate/controller/mateController.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/mate/controller/mateController.java
@@ -1,12 +1,11 @@
 package com.fittogether.server.dm.mate.controller;
 
+import com.fittogether.server.dm.domain.dto.ChattingDto;
 import com.fittogether.server.dm.domain.dto.RequestDto;
 import com.fittogether.server.dm.domain.dto.RequestForm;
 import com.fittogether.server.dm.service.MateService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 public class mateController {
@@ -26,7 +25,13 @@ public class mateController {
           return ResponseEntity.ok(mateService.mateRequest(requestForm));
     }
 
-
+    @PutMapping("/matching/request")
+    public ResponseEntity<ChattingDto> mateAccept(
+            //@RequestHeader("token") String token
+            @RequestParam boolean is_matched
+    ){
+        return null;
+    }
 
 
 }

--- a/server/dm/src/main/java/com/fittogether/server/dm/mate/controller/mateController.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/mate/controller/mateController.java
@@ -1,13 +1,12 @@
 package com.fittogether.server.dm.mate.controller;
 
-import com.fittogether.server.dm.domain.dto.ChatRoomDto;
+import com.fittogether.server.dm.domain.dto.RequestDto;
 import com.fittogether.server.dm.domain.dto.RequestForm;
-import com.fittogether.server.dm.domain.dto.ChattingDto;
 import com.fittogether.server.dm.service.MateService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDateTime;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class mateController {
@@ -20,7 +19,7 @@ public class mateController {
 
 
     @PostMapping("/matching/request")
-    public ResponseEntity<ChattingDto> mateRequest(
+    public ResponseEntity<RequestDto> mateRequest(
             //@RequestHeader("token") String token
             @RequestBody RequestForm requestForm
     ){

--- a/server/dm/src/main/java/com/fittogether/server/dm/mate/controller/mateController.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/mate/controller/mateController.java
@@ -31,7 +31,7 @@ public class mateController {
             @PathVariable Long senderId,
             @RequestParam boolean is_matched
     ){
-        return null;
+        return ResponseEntity.ok(mateService.mateAccept(senderId,is_matched));
     }
 
 

--- a/server/dm/src/main/java/com/fittogether/server/dm/mate/controller/mateController.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/mate/controller/mateController.java
@@ -1,11 +1,13 @@
 package com.fittogether.server.dm.mate.controller;
 
-import com.fittogether.server.dm.domain.dto.ChattingDto;
 import com.fittogether.server.dm.domain.dto.RequestDto;
 import com.fittogether.server.dm.domain.dto.RequestForm;
 import com.fittogether.server.dm.service.MateService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 public class mateController {
@@ -26,13 +28,18 @@ public class mateController {
     }
 
     @PutMapping("/matching/{senderId}")
-    public ResponseEntity<ChattingDto> mateAccept(
+    public ResponseEntity<Object> mateAccept(
             //@RequestHeader("token") String token
             @PathVariable Long senderId,
             @RequestParam boolean is_matched
     ){
-        return ResponseEntity.ok(mateService.mateAccept(senderId,is_matched));
-    }
+        mateService.mateAccept(senderId,is_matched);
 
+        Map<String, Object> responseData = new HashMap<>();
+        responseData.put("status", "success");
+        responseData.put("message", "메이트 수락 완료");
+
+        return ResponseEntity.ok(responseData);
+    }
 
 }

--- a/server/dm/src/main/java/com/fittogether/server/dm/mate/controller/mateController.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/mate/controller/mateController.java
@@ -25,9 +25,10 @@ public class mateController {
           return ResponseEntity.ok(mateService.mateRequest(requestForm));
     }
 
-    @PutMapping("/matching/request")
+    @PutMapping("/matching/{senderId}")
     public ResponseEntity<ChattingDto> mateAccept(
             //@RequestHeader("token") String token
+            @PathVariable Long senderId,
             @RequestParam boolean is_matched
     ){
         return null;

--- a/server/dm/src/main/java/com/fittogether/server/dm/service/MateService.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/service/MateService.java
@@ -1,24 +1,19 @@
 package com.fittogether.server.dm.service;
 
-import com.fittogether.server.dm.domain.dto.ChattingDto;
 import com.fittogether.server.dm.domain.dto.RequestDto;
 import com.fittogether.server.dm.domain.dto.RequestForm;
-import com.fittogether.server.dm.domain.entity.ChatRoom;
 import com.fittogether.server.dm.domain.entity.Request;
-import com.fittogether.server.dm.domain.repository.ChatRoomRepository;
 import com.fittogether.server.dm.domain.repository.RequestRepository;
-import com.fittogether.server.dm.exception.validateErrorCode;
+import com.fittogether.server.dm.exception.MateExceptionCode;
 import com.fittogether.server.domain.token.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
 @Service
 public class MateService {
     private final RequestRepository requestRepository;
-    private final ChatRoomRepository chatRoomRepository;
+
     private final JwtProvider jwtProvider;
 
 
@@ -27,7 +22,7 @@ public class MateService {
             //String token,
             RequestForm requestForm
     ) {
-        /* if (!jwtProvider.validateToken("token")) {
+        /* if (!jwtProvider.validateToken(token)) {
             throw new validateErrorCode("유효하지 않은 토큰입니다");
         }
         */
@@ -41,22 +36,22 @@ public class MateService {
 
 
     //운동 메이트 수락
-    public ChattingDto mateAccept(Long senderId,boolean is_matched ) {
-
-        if(is_matched==false){
-            return null;
+    public void mateAccept(Long senderId, boolean is_matched) {
+         /* if (!jwtProvider.validateToken(token)) {
+            throw new validateErrorCode("유효하지 않은 토큰입니다");
         }
+        */
 
-        Request request =requestRepository.findAllBySenderId(senderId);
+        if (!is_matched) {
+            throw new MateExceptionCode("요청 거절");
+        }
+        Request request = requestRepository.findAllBySenderId(senderId);
         request.setAccepted(true);
 
         requestRepository.save(request);
 
-        return null;
+
     }
-
-    //
-
 
 
 }

--- a/server/dm/src/main/java/com/fittogether/server/dm/service/MateService.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/service/MateService.java
@@ -1,12 +1,16 @@
 package com.fittogether.server.dm.service;
 
+import com.fittogether.server.dm.domain.dto.ChattingDto;
 import com.fittogether.server.dm.domain.dto.RequestDto;
 import com.fittogether.server.dm.domain.dto.RequestForm;
+import com.fittogether.server.dm.domain.entity.ChatRoom;
 import com.fittogether.server.dm.domain.entity.Request;
 import com.fittogether.server.dm.domain.repository.ChatRoomRepository;
 import com.fittogether.server.dm.domain.repository.RequestRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
 @Service
@@ -26,6 +30,25 @@ public class MateService {
 
         return RequestDto.from(request);
     }
+
+
+    //운동 메이트 수락
+    public ChattingDto mateAccept(Long senderId,boolean is_matched ) {
+
+        if(is_matched==false){
+            return null;
+        }
+
+        Request request =requestRepository.findAllBySenderId(senderId);
+        request.setAccepted(true);
+
+        requestRepository.save(request);
+
+        return null;
+    }
+
+    //
+
 
 
 }

--- a/server/dm/src/main/java/com/fittogether/server/dm/service/MateService.java
+++ b/server/dm/src/main/java/com/fittogether/server/dm/service/MateService.java
@@ -1,16 +1,12 @@
 package com.fittogether.server.dm.service;
 
-import com.fittogether.server.dm.domain.dto.ChatRoomDto;
-import com.fittogether.server.dm.domain.dto.ChattingDto;
+import com.fittogether.server.dm.domain.dto.RequestDto;
 import com.fittogether.server.dm.domain.dto.RequestForm;
-import com.fittogether.server.dm.domain.entity.ChatRoom;
 import com.fittogether.server.dm.domain.entity.Request;
 import com.fittogether.server.dm.domain.repository.ChatRoomRepository;
 import com.fittogether.server.dm.domain.repository.RequestRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
 @Service
@@ -21,23 +17,15 @@ public class MateService {
 
 
     // 운동 메이트 요청
-    public ChattingDto mateRequest(RequestForm requestForm ) {
+    public RequestDto mateRequest(RequestForm requestForm) {
 
         Request request = Request.from(requestForm);
-        ChatRoom chatRoom=new ChatRoom();
 
-        chatRoomRepository.save(chatRoom);
         requestRepository.save(request);
 
-        return ChattingDto.requestFrom(request,chatRoom);
-    }
 
-//    public ChattingDto mateAccept(
-//            String token,Long roomId, boolean is_matched
-//    ){
-//            Request request ;
-//            request.setAccepted(true);
-//    }
+        return RequestDto.from(request);
+    }
 
 
 }


### PR DESCRIPTION
 # 메이트 수락
별도의 dto반환없이 수락시 request의 isAccept가 true 변경되게 구현했습니다.

메이트 수락시 자동으로 채팅방이 생성되는게 아니므로 , @PathVariable roomId를 senderId로 수정했습니다.
api 명세서 수정했습니다.

postman으로 테스트하였고 , 테스트 코드 작성하겠습니다.