### PR TITLE
Feat : [posts] - 좋아요 기능 구현, 캐싱 적용

### DIFF
--- a/server/posts/build.gradle
+++ b/server/posts/build.gradle
@@ -17,8 +17,12 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:2.6.1'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'

--- a/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.fittogether.server.posts.controller;
 
+import com.fittogether.server.posts.domain.dto.LikeDto;
 import com.fittogether.server.posts.domain.dto.PostDto;
 import com.fittogether.server.posts.domain.dto.PostForm;
 import com.fittogether.server.posts.domain.dto.PostInfo;
@@ -61,5 +62,12 @@ public class PostController {
     return ResponseEntity.ok(
         postService.getPostById(postId));
 
+  }
+
+  @PostMapping("/posts/{postId}/like")
+  public ResponseEntity<LikeDto> likePost(@RequestHeader(name = "X-AUTH-TOKEN") String token,
+                                          @PathVariable Long postId) {
+    return ResponseEntity.ok(LikeDto.from(
+        postService.likePost(token, postId)));
   }
 }

--- a/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
@@ -73,11 +73,4 @@ public class PostController {
     return ResponseEntity.ok(LikeDto.from(
         likeService.likePost(token, postId)));
   }
-
-  @GetMapping("/posts")
-  public ResponseEntity<PostPageDto> getPostByPage(@RequestParam(defaultValue = "0") int page,
-                                     @RequestParam(defaultValue = "5") int size) {
-    return ResponseEntity.ok(PostPageDto.from(
-        postService.getPostsByPage(page,size)));
-  }
 }

--- a/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController

--- a/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
@@ -4,8 +4,10 @@ import com.fittogether.server.posts.domain.dto.LikeDto;
 import com.fittogether.server.posts.domain.dto.PostDto;
 import com.fittogether.server.posts.domain.dto.PostForm;
 import com.fittogether.server.posts.domain.dto.PostInfo;
+import com.fittogether.server.posts.domain.dto.PostPageDto;
 import com.fittogether.server.posts.domain.dto.ReplyDto;
 import com.fittogether.server.posts.domain.dto.ReplyForm;
+import com.fittogether.server.posts.service.LikeService;
 import com.fittogether.server.posts.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
   private final PostService postService;
+  private final LikeService likeService;
 
   @PostMapping("/posts")
   public ResponseEntity<PostDto> createPost(@RequestHeader(name = "X-AUTH-TOKEN") String token,
@@ -57,17 +61,23 @@ public class PostController {
   }
 
   @GetMapping("posts/{postId}")
-  public ResponseEntity<PostInfo> getPost(@PathVariable Long postId) {
+  public ResponseEntity<PostInfo> clickPost(@PathVariable Long postId) {
 
     return ResponseEntity.ok(
-        postService.getPostById(postId));
-
+        postService.clickPostById(postId));
   }
 
   @PostMapping("/posts/{postId}/like")
   public ResponseEntity<LikeDto> likePost(@RequestHeader(name = "X-AUTH-TOKEN") String token,
                                           @PathVariable Long postId) {
     return ResponseEntity.ok(LikeDto.from(
-        postService.likePost(token, postId)));
+        likeService.likePost(token, postId)));
+  }
+
+  @GetMapping("/posts")
+  public ResponseEntity<PostPageDto> getPostByPage(@RequestParam(defaultValue = "0") int page,
+                                     @RequestParam(defaultValue = "5") int size) {
+    return ResponseEntity.ok(PostPageDto.from(
+        postService.getPostsByPage(page,size)));
   }
 }

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/LikeDto.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/LikeDto.java
@@ -1,0 +1,20 @@
+package com.fittogether.server.posts.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LikeDto {
+  private boolean like;
+
+  public static LikeDto from(boolean like) {
+    return LikeDto.builder()
+        .like(like)
+        .build();
+  }
+}

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyDto.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyDto.java
@@ -14,7 +14,6 @@ import lombok.NoArgsConstructor;
 public class ReplyDto {
   private String comment;
   private LocalDateTime createdAt;
-  private LocalDateTime modifiedAt;
   private String userNickname;
   private Long postId;
 

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Like.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Like.java
@@ -1,11 +1,7 @@
 package com.fittogether.server.posts.domain.model;
 
-import com.fittogether.server.posts.type.Category;
 import com.fittogether.server.user.domain.model.User;
-import java.time.LocalDateTime;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -22,28 +18,18 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Entity
-public class Post {
+@Entity(name = "post_like")
+public class Like {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @ManyToOne
+  @JoinColumn(name = "post_id")
+  private Post post;
+
+  @ManyToOne
   @JoinColumn(name = "user_id")
   private User user;
-
-  private String title;
-  private String description;
-  private String image;
-
-  @Enumerated(value = EnumType.STRING)
-  private Category category;
-  private Long likes;
-  private Long watched;
-  private boolean accessLevel;
-
-  private LocalDateTime createdAt;
-  private LocalDateTime modifiedAt;
-
 }

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/repository/LikeRepository.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/repository/LikeRepository.java
@@ -3,9 +3,12 @@ package com.fittogether.server.posts.domain.repository;
 import com.fittogether.server.posts.domain.model.Like;
 import com.fittogether.server.posts.domain.model.Post;
 import com.fittogether.server.user.domain.model.User;
+import javax.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
   Long countByPostId(Long postId);
 
   void deleteByPostAndUser(Post post, User user);

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/repository/LikeRepository.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/repository/LikeRepository.java
@@ -1,0 +1,14 @@
+package com.fittogether.server.posts.domain.repository;
+
+import com.fittogether.server.posts.domain.model.Like;
+import com.fittogether.server.posts.domain.model.Post;
+import com.fittogether.server.user.domain.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+  Long countByPostId(Long postId);
+
+  void deleteByPostAndUser(Post post, User user);
+
+  Like findByPostAndUser(Post post, User user);
+}

--- a/server/posts/src/main/java/com/fittogether/server/posts/service/LikeService.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/service/LikeService.java
@@ -45,7 +45,6 @@ public class LikeService {
         .orElseThrow(() -> new UserCustomException(UserErrorCode.NOT_FOUND_USER));
 
 
-    synchronized (postId.toString().intern()) {
       Like existingLike = likeRepository.findByPostAndUser(post, user);
 
       if (existingLike != null) {
@@ -63,7 +62,6 @@ public class LikeService {
       }
 
       return existingLike == null;
-    }
   }
 
   /**

--- a/server/posts/src/main/java/com/fittogether/server/posts/service/LikeService.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/service/LikeService.java
@@ -1,0 +1,87 @@
+package com.fittogether.server.posts.service;
+
+import com.fittogether.server.domain.token.JwtProvider;
+import com.fittogether.server.domain.token.UserVo;
+import com.fittogether.server.posts.domain.model.Like;
+import com.fittogether.server.posts.domain.model.Post;
+import com.fittogether.server.posts.domain.repository.LikeRepository;
+import com.fittogether.server.posts.domain.repository.PostRepository;
+import com.fittogether.server.posts.exception.ErrorCode;
+import com.fittogether.server.posts.exception.PostException;
+import com.fittogether.server.user.domain.model.User;
+import com.fittogether.server.user.domain.repository.UserRepository;
+import com.fittogether.server.user.exception.UserCustomException;
+import com.fittogether.server.user.exception.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+  private final PostRepository postRepository;
+  private final UserRepository userRepository;
+  private final LikeRepository likeRepository;
+  private final CacheManager cacheManager;
+  private final JwtProvider provider;
+
+  @Transactional
+  public boolean likePost(String token, Long postId) {
+
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new PostException(ErrorCode.NOT_FOUND_POST));
+
+    if (!provider.validateToken(token)) {
+      throw new RuntimeException("Invalid or expired token.");
+    }
+
+    UserVo userVo = provider.getUserVo(token);
+    User user = userRepository.findById(userVo.getUserId())
+        .orElseThrow(() -> new UserCustomException(UserErrorCode.NOT_FOUND_USER));
+
+
+    synchronized (postId.toString().intern()) {
+      Like existingLike = likeRepository.findByPostAndUser(post, user);
+
+      if (existingLike != null) {
+        likeRepository.deleteByPostAndUser(post, user);
+        post.setLikes(postLikeCount(postId));
+        evictPostLikeCount(postId);
+      } else {
+        post.setLikes(postLikeCount(postId) + 1);
+        Like like = Like.builder()
+            .post(post)
+            .user(user)
+            .build();
+        likeRepository.save(like);
+        evictPostLikeCount(postId);
+      }
+
+      return existingLike == null;
+    }
+  }
+
+  /**
+   * 게시글 좋아요 수 캐싱
+   */
+  @Cacheable(value = "postLikeCount", key = "#postId")
+  public Long postLikeCount(Long postId) {
+    return likeRepository.countByPostId(postId);
+  }
+
+  /**
+   * 캐시 갱신
+   */
+  @CacheEvict(value = "postLikeCount", key = "#postId")
+  public void evictPostLikeCount(Long postId) {
+    Cache cache = cacheManager.getCache("postLikeCount");
+    if (cache != null) {
+      cache.evict(postId);
+    }
+  }
+}

--- a/server/posts/src/main/java/com/fittogether/server/posts/service/PostService.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/service/PostService.java
@@ -216,8 +216,8 @@ public class PostService {
 
     if (existingLike != null) {
       likeRepository.deleteByPostAndUser(post, user);
-      evictPostLikeCount(postId);
       post.setLikes(post.getLikes() - 1);
+      evictPostLikeCount(postId);
     } else {
       Like like = Like.builder()
           .post(post)

--- a/server/posts/src/test/java/com/fittogether/server/posts/service/PostServiceTest.java
+++ b/server/posts/src/test/java/com/fittogether/server/posts/service/PostServiceTest.java
@@ -1,0 +1,111 @@
+package com.fittogether.server.posts.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fittogether.server.domain.token.JwtProvider;
+import com.fittogether.server.domain.token.UserVo;
+import com.fittogether.server.posts.domain.model.Like;
+import com.fittogether.server.posts.domain.model.Post;
+import com.fittogether.server.posts.domain.repository.LikeRepository;
+import com.fittogether.server.posts.domain.repository.PostRepository;
+import com.fittogether.server.user.domain.model.User;
+import com.fittogether.server.user.domain.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+@ExtendWith(MockitoExtension.class)
+public class PostServiceTest {
+
+  @InjectMocks
+  private LikeService likeService;
+
+  @Mock
+  private PostRepository postRepository;
+
+  @Mock
+  private UserRepository userRepository;
+  @Mock
+  private LikeRepository likeRepository;
+
+  @Mock
+  private CacheManager cacheManager;
+
+  @Mock
+  private JwtProvider provider;
+
+
+  @Test
+  void testLikePost() {
+
+    when(provider.validateToken(anyString())).thenReturn(true);
+
+    UserVo userVo = new UserVo(1L, "test");
+    when(provider.getUserVo(anyString())).thenReturn(userVo);
+
+    User user = User.builder()
+        .userId(1L)
+        .nickname("test")
+        .password("1234")
+        .build();
+
+    Post post = Post.builder()
+        .user(user)
+        .id(1L)
+        .likes(0L)
+        .build();
+
+    when(userRepository.findById(userVo.getUserId())).thenReturn(Optional.of(user));
+
+    when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+
+    when(likeRepository.save(any(Like.class))).thenReturn(new Like());
+
+
+    boolean result = likeService.likePost("token", post.getId());
+
+    assertTrue(result);
+
+    verify(postRepository, times(1)).findById(post.getId());
+    verify(likeRepository, times(1)).findByPostAndUser(post, user);
+    verify(likeRepository, times(1)).save(any(Like.class));
+  }
+
+  @Test
+  void testGetPostLikeCount() {
+    Long postId = 1L;
+    long likeCount = 10L;
+
+    when(likeRepository.countByPostId(postId)).thenReturn(likeCount);
+
+    Long result = likeService.postLikeCount(postId);
+
+    assertEquals(likeCount, result);
+    verify(likeRepository, times(1)).countByPostId(postId);
+  }
+
+  @Test
+  void testEvictPostLikeCount() {
+    Long postId = 1L;
+
+    Cache cache = mock(Cache.class);
+    when(cacheManager.getCache("postLikeCount")).thenReturn(cache);
+
+    likeService.evictPostLikeCount(postId);
+
+    verify(cacheManager, times(1)).getCache("postLikeCount");
+    verify(cache, times(1)).evict(postId);
+  }
+}


### PR DESCRIPTION
Like Entity는 User와 Post 관계 맵핑하여 구성했습니다.

- 좋아요 클릭 ( @PostMapping("/posts/{postId}/like") )
토큰 검증 후  findByPostAndUser를 통해 해당 유저가 해당 게시글을 좋아요를 했는지 찾습니다.
좋아요를 한 정보가 없다면 postLikeCount()메서드로 db에 저장된 좋아요 수를 가져와 +1을하여 저장하고 캐시를 갱신합니다.
좋아요를 한 기록이 있다면 좋아요를 취소하고 evictPostLikeCount 로 캐시를 갱신합니다.

글 작성 시 초기 좋아요는 0으로 설정
좋아요를 카운트하는 postLikeCount()메서드에 캐싱을 설정했습니다
그리고 postLikeCount()메서드에 서 불러오는 postRepository의 countByPostId에 비관적 락을 걸어 충동 가능성을 낮췄습니다.