### PR TITLE
Feat : [posts] - 레디스를 통한 조회수 구현

### DIFF
--- a/server/posts/src/main/java/com/fittogether/server/posts/type/Category.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/type/Category.java
@@ -1,5 +1,5 @@
 package com.fittogether.server.posts.type;
 
 public enum Category {
-  WEIGHT,RUNNING,CLIMBING
+  RUNNING, HIKING, WEIGHT
 }

--- a/server/src/main/java/com/fittogether/server/config/RedisConfig.java
+++ b/server/src/main/java/com/fittogether/server/config/RedisConfig.java
@@ -11,9 +11,11 @@ import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @RequiredArgsConstructor
@@ -27,6 +29,15 @@ public class RedisConfig extends CachingConfigurerSupport {
 
   @Value("${spring.redis.ttl-duration}")
   private Long duration;
+
+  @Bean
+  public RedisTemplate<?, ?> redisTemplate() {
+    RedisTemplate<byte[], byte[]> template = new RedisTemplate<>();
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new StringRedisSerializer());
+    template.setConnectionFactory(lettuceConnectionFactory());
+    return template;
+  }
 
   @Bean
   public LettuceConnectionFactory lettuceConnectionFactory() {


### PR DESCRIPTION
RedisTemplate를 사용하여
게시글을 봤을때 incrementWatchedCount 메서드를 구현하여 조회수 증가
incrementWatchedCount는
postId를 통해 조회수를 관리하는 key를 생성, ValueOperations 를 사용해서 post.getWatched로 조회수를 가져와 캐싱을하고
유효기간을 5분으로 지정했습니다.
increment메서드로 레디스에 조회수를 증가시키고 그 증가시킨 값이 db에 업데이트 되도록 구현헀습니다.