### PR TITLE
Feat : [posts] - 이미지 업로드

### DIFF
--- a/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
@@ -16,7 +16,9 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,8 +34,8 @@ public class PostController {
 
     return ResponseEntity.ok(PostDto.from(
         postService.createPost(token, postForm)));
-
   }
+
   @GetMapping("/{postId}")
   public ResponseEntity<PostInfo> clickPost(@PathVariable Long postId) {
 
@@ -60,8 +62,16 @@ public class PostController {
 
   @PostMapping("/{postId}/like")
   public ResponseEntity<LikeDto> likePost(@RequestHeader(name = "X-AUTH-TOKEN") String token,
-                                          @PathVariable Long postId) {
+      @PathVariable Long postId) {
     return ResponseEntity.ok(LikeDto.from(
         likeService.likePost(token, postId)));
+  }
+
+
+  @PostMapping("/upload")
+  public ResponseEntity<String> uploadImage(@RequestParam("file") MultipartFile file) {
+
+    return ResponseEntity.ok(
+        postService.uploadImage(file));
   }
 }

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostForm.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostForm.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @NoArgsConstructor
@@ -15,7 +16,7 @@ public class PostForm {
 
   private String title;
   private String description;
-  private String image;
+  private MultipartFile image;
   private Category category;
   private boolean accessLevel;
   private List<String> hashtag;

--- a/server/posts/src/main/java/com/fittogether/server/posts/type/Category.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/type/Category.java
@@ -1,5 +1,5 @@
 package com.fittogether.server.posts.type;
 
 public enum Category {
-  WEIGHT,RUNNING,CLIMBING
+  RUNNING, HIKING, WEIGHT
 }

--- a/server/src/main/java/com/fittogether/server/config/RedisConfig.java
+++ b/server/src/main/java/com/fittogether/server/config/RedisConfig.java
@@ -11,9 +11,11 @@ import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @RequiredArgsConstructor
@@ -27,6 +29,15 @@ public class RedisConfig extends CachingConfigurerSupport {
 
   @Value("${spring.redis.ttl-duration}")
   private Long duration;
+
+  @Bean
+  public RedisTemplate<?, ?> redisTemplate() {
+    RedisTemplate<byte[], byte[]> template = new RedisTemplate<>();
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new StringRedisSerializer());
+    template.setConnectionFactory(lettuceConnectionFactory());
+    return template;
+  }
 
   @Bean
   public LettuceConnectionFactory lettuceConnectionFactory() {


### PR DESCRIPTION
이미지 파일 이름과 UUID를 결합하여 고유한 파일 이름을 생성합니다.
생성된 파일 이름과 uploadPath를 사용하여 파일이 저장될 경로인 filePath를 생성합니다.

Files.copy를 사용하여 업로드된 이미지 파일의 내용을 filePath로 복사합니다.
복사가 완료되면 저장된 파일 경로인 filePath를 반환합니다.