### PR TITLE
feat: [user] - 3km 내 사용자 조회

### DIFF
--- a/server/user/build.gradle
+++ b/server/user/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
     implementation 'org.springframework.data:spring-data-envers'
 
+    implementation 'com.google.code.gson:gson:2.8.5'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/server/user/src/main/java/com/fittogether/server/user/controller/LocationController.java
+++ b/server/user/src/main/java/com/fittogether/server/user/controller/LocationController.java
@@ -1,10 +1,13 @@
 package com.fittogether.server.user.controller;
 
+import com.fittogether.server.user.domain.dto.AnotherUserDto;
 import com.fittogether.server.user.service.LocationService;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/location")
@@ -19,5 +22,11 @@ public class LocationController {
 
         locationService.updateMyLocation(token, latitude, longitude);
         return ResponseEntity.ok().body("나의 위치를 업데이트 완료");
+    }
+
+    @ApiOperation(value = "3km 내 사용자 조회")
+    @GetMapping("/map")
+    public ResponseEntity<List<AnotherUserDto>> getUserWithinBoundary(@RequestHeader(name = "X-AUTH-TOKEN") String token) {
+        return ResponseEntity.ok(locationService.getUsersWithin3km(token));
     }
 }

--- a/server/user/src/main/java/com/fittogether/server/user/domain/dto/AnotherUserDto.java
+++ b/server/user/src/main/java/com/fittogether/server/user/domain/dto/AnotherUserDto.java
@@ -2,16 +2,20 @@ package com.fittogether.server.user.domain.dto;
 
 import com.fittogether.server.user.domain.model.User;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.util.List;
 
 @Builder
+@Getter
 public class AnotherUserDto {
     private Long userId;
     private String nickname;
     private boolean gender;
     private String introduction;
     private List<ExerciseType> exerciseChoice;
+    private Double latitude;
+    private Double longitude;
 
     public static AnotherUserDto from(User user) {
         return AnotherUserDto.builder()
@@ -20,6 +24,8 @@ public class AnotherUserDto {
                 .gender(user.isGender())
                 .introduction(user.getIntroduction())
                 .exerciseChoice(user.getExerciseChoice())
+                .latitude(user.getLatitude())
+                .longitude(user.getLongitude())
                 .build();
     }
 }

--- a/server/user/src/main/java/com/fittogether/server/user/domain/repository/UserRepository.java
+++ b/server/user/src/main/java/com/fittogether/server/user/domain/repository/UserRepository.java
@@ -4,6 +4,7 @@ import com.fittogether.server.user.domain.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,4 +16,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByNicknameAndPassword(String nickname, String password);
 
     Optional<User> findByEmail(String email);
+
+    List<User> findByLatitudeBetweenAndLongitudeBetweenAndPublicInfo(double minLat, double maxLat,
+                                                                     double minLng, double maxLng, boolean publicInfo);
 }

--- a/server/user/src/main/java/com/fittogether/server/user/exception/UserErrorCode.java
+++ b/server/user/src/main/java/com/fittogether/server/user/exception/UserErrorCode.java
@@ -12,7 +12,7 @@ public enum UserErrorCode {
     ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
 
     // 로그인
-    NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "닉네임과 비밀번호를 다시 확인해주세요."),
+    NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "일치하는 회원이 없습니다."),
     NOT_FOR_FITTOGETHER(HttpStatus.BAD_REQUEST, "소셜 로그인으로 다시 로그인해주세요."),
 
     NEED_TO_SIGNIN(HttpStatus.BAD_REQUEST, "로그인이 필요합니다."),

--- a/server/user/src/main/java/com/fittogether/server/user/service/LocationService.java
+++ b/server/user/src/main/java/com/fittogether/server/user/service/LocationService.java
@@ -2,6 +2,7 @@ package com.fittogether.server.user.service;
 
 import com.fittogether.server.domain.token.JwtProvider;
 import com.fittogether.server.domain.token.UserVo;
+import com.fittogether.server.user.domain.dto.AnotherUserDto;
 import com.fittogether.server.user.domain.model.User;
 import com.fittogether.server.user.domain.repository.UserRepository;
 import com.fittogether.server.user.exception.UserCustomException;
@@ -10,11 +11,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class LocationService {
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
+    private static final double EARTHRADIUS = 6371;
+    private static final int BOUNDARY = 3;
 
     // 현재 나의 위치 업데이트
     @Transactional
@@ -29,5 +37,52 @@ public class LocationService {
 
         user.setLatitude(latitude);
         user.setLongitude(longitude);
+    }
+
+    public List<AnotherUserDto> getUsersWithin3km(String token) {
+        if (!jwtProvider.validateToken(token)) {
+            throw new UserCustomException(UserErrorCode.NEED_TO_SIGNIN);
+        }
+
+        UserVo userVo = jwtProvider.getUserVo(token);
+        User user = userRepository.findById(userVo.getUserId())
+                .orElseThrow(() -> new UserCustomException(UserErrorCode.NOT_FOUND_USER));
+
+        double lat = user.getLatitude();
+        double lng = user.getLongitude();
+
+        Map<String, Double> boundary = calculateRangeLatAndLng(lat, lng);
+        double minLat = boundary.get("minLat");
+        double maxLat = boundary.get("maxLat");
+        double minLng = boundary.get("minLng");
+        double maxLng = boundary.get("maxLng");
+
+        List<User> users = userRepository.findByLatitudeBetweenAndLongitudeBetweenAndPublicInfo(
+                minLat, maxLat, minLng, maxLng, true);
+
+        if (users.isEmpty()) {
+            throw new UserCustomException(UserErrorCode.NOT_FOUND_USER);
+        }
+
+        return users.stream().map(AnotherUserDto::from).collect(Collectors.toList());
+    }
+
+    // 3km 내 위도, 경도 범위 구하기
+    private Map<String, Double> calculateRangeLatAndLng(double lat, double lng) {
+        double latRange = Math.toDegrees(BOUNDARY / EARTHRADIUS);
+        double lngRange = Math.toDegrees(BOUNDARY / (EARTHRADIUS * Math.cos(Math.toRadians(lat))));
+
+        double minLat = lat - latRange;
+        double maxLat = lat + latRange;
+        double minLng = lng - lngRange;
+        double maxLng = lng + lngRange;
+
+        Map<String, Double> result = new HashMap<>();
+        result.put("minLat", minLat);
+        result.put("maxLat", maxLat);
+        result.put("minLng", minLng);
+        result.put("maxLng", maxLng);
+
+        return result;
     }
 }


### PR DESCRIPTION
##Changes

- `get` : /location/map
- `header` : token
- `return` : List of AnotherUserDto
   - AnotherUserDto: 중요정보를 뺀 사용자 정보
- `contents` : 로그인 한 사용자는 자기 위치(위도, 경도) 기준 3km 내의 사용자를 볼 수 있다. 이때, 계정을 공개로 설정한 사용자만 지도에 표시되도록 값을 반환하도록 한다.