### PR TITLE
Refactor : [posts] - 좋아요 및 조회수 캐싱

### DIFF
--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostInfo.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostInfo.java
@@ -26,11 +26,12 @@ public class PostInfo {
   private Long likeCount;
   private Long viewCount;
   private Long replyCount;
+  private boolean isLike;
   private List<ReplyDto> replyList;
   private List<ReplyDto> childReplyList;
   private LocalDateTime createdAt;
 
-  public static PostInfo from(Post post, List<Reply> replyList, List<ChildReply> childReplyList, Long totalCount) {
+  public static PostInfo from(Post post, List<Reply> replyList, List<ChildReply> childReplyList, Long totalCount, boolean isLike, Long incrementWatchedCount) {
 
     return PostInfo.builder()
         .userId(post.getUser().getUserId())
@@ -39,8 +40,9 @@ public class PostInfo {
         .description(post.getDescription())
         .image(post.getImage())
         .likeCount(post.getLikes())
-        .viewCount(post.getWatched())
+        .viewCount(incrementWatchedCount)
         .replyCount(totalCount)
+        .isLike(isLike)
         .replyList(replyList.stream().map(ReplyDto::from).collect(Collectors.toList()))
         .childReplyList(childReplyList.stream().map(ReplyDto::fromChild).collect(Collectors.toList()))
         .createdAt(post.getCreatedAt())

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Like.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Like.java
@@ -7,6 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Version;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,4 +33,7 @@ public class Like {
   @ManyToOne
   @JoinColumn(name = "user_id")
   private User user;
+
+  @Version
+  private Long version;
 }

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/repository/LikeRepository.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/repository/LikeRepository.java
@@ -3,15 +3,14 @@ package com.fittogether.server.posts.domain.repository;
 import com.fittogether.server.posts.domain.model.Like;
 import com.fittogether.server.posts.domain.model.Post;
 import com.fittogether.server.user.domain.model.User;
-import javax.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
-  @Lock(LockModeType.PESSIMISTIC_WRITE)
   Long countByPostId(Long postId);
 
   void deleteByPostAndUser(Post post, User user);
 
-  Like findByPostAndUser(Post post, User user);
+  boolean existsByPost(Post post);
+
+  boolean existsByPostAndUser(Post post, User user);
 }

--- a/server/posts/src/main/java/com/fittogether/server/posts/service/LikeService.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/service/LikeService.java
@@ -12,24 +12,32 @@ import com.fittogether.server.user.domain.model.User;
 import com.fittogether.server.user.domain.repository.UserRepository;
 import com.fittogether.server.user.exception.UserCustomException;
 import com.fittogether.server.user.exception.UserErrorCode;
+import java.util.Iterator;
+import java.util.Set;
+import javax.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.Cache;
-import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class LikeService {
 
   private final PostRepository postRepository;
   private final UserRepository userRepository;
   private final LikeRepository likeRepository;
-  private final CacheManager cacheManager;
   private final JwtProvider provider;
+  private final RedisTemplate<String, String> redisTemplate;
 
+  /**
+   * 좋아요 클릭
+   */
   @Transactional
   public boolean likePost(String token, Long postId) {
 
@@ -44,42 +52,67 @@ public class LikeService {
     User user = userRepository.findById(userVo.getUserId())
         .orElseThrow(() -> new UserCustomException(UserErrorCode.NOT_FOUND_USER));
 
-
-      Like existingLike = likeRepository.findByPostAndUser(post, user);
-
-      if (existingLike != null) {
-        likeRepository.deleteByPostAndUser(post, user);
-        post.setLikes(postLikeCount(postId));
-        evictPostLikeCount(postId);
-      } else {
-        post.setLikes(postLikeCount(postId) + 1);
-        Like like = Like.builder()
-            .post(post)
-            .user(user)
-            .build();
-        likeRepository.save(like);
-        evictPostLikeCount(postId);
-      }
-
-      return existingLike == null;
+    return LikeToggle(post, user);
   }
 
-  /**
-   * 게시글 좋아요 수 캐싱
-   */
-  @Cacheable(value = "postLikeCount", key = "#postId")
-  public Long postLikeCount(Long postId) {
-    return likeRepository.countByPostId(postId);
-  }
+  @Lock(LockModeType.OPTIMISTIC)
+  private boolean LikeToggle(Post post, User user) {
+    boolean isLiked = likeRepository.existsByPostAndUser(post, user);
 
-  /**
-   * 캐시 갱신
-   */
-  @CacheEvict(value = "postLikeCount", key = "#postId")
-  public void evictPostLikeCount(Long postId) {
-    Cache cache = cacheManager.getCache("postLikeCount");
-    if (cache != null) {
-      cache.evict(postId);
+    // 좋아요 토글
+    if (isLiked) { // 좋아요 눌린 상태에서 취소
+      likeRepository.deleteByPostAndUser(post, user);
+      getCachedLikeCount(post.getId(), true);
+    } else { // 좋아요 눌리지 않은 상태에서 좋아요
+      Like like = Like.builder()
+          .post(post)
+          .user(user)
+          .build();
+      likeRepository.save(like);
+      getCachedLikeCount(post.getId(), false);
     }
+
+    return !isLiked;
+  }
+
+  @Transactional
+  public void getCachedLikeCount(Long postId, boolean isLiked) {
+    String likeCountKey = "postLikeCount::" + postId;
+
+    ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+    if (valueOperations.get(likeCountKey) == null) {
+      Long likeCount = likeRepository.countByPostId(postId);
+      valueOperations.set(likeCountKey, String.valueOf(likeCount));
+    } else {
+      if (isLiked) {
+        valueOperations.decrement(likeCountKey);
+      } else {
+        valueOperations.increment(likeCountKey);
+      }
+    }
+  }
+
+  @Scheduled(cron = "0 0/3 * * * *")
+  public void updateLikeCountRedis() {
+    log.info("DB 좋아요 수 갱신");
+    Set<String> keys = redisTemplate.keys("postLikeCount::*");
+    Iterator<String> it = keys.iterator();
+    while (it.hasNext()) {
+      String data = it.next();
+      Long postId = Long.parseLong(data.split("::")[1]);
+      Long likeCount = Long.parseLong(redisTemplate.opsForValue().get(data));
+      updateLikeCountDB(postId, likeCount);
+      redisTemplate.delete("postLikeCount::" + postId);
+    }
+  }
+
+  @Transactional
+  public void updateLikeCountDB(Long postId, Long likeCount) {
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new PostException(ErrorCode.NOT_FOUND_POST));
+
+    post.setLikes(likeCount);
+    postRepository.save(post);
   }
 }

--- a/server/src/main/java/com/fittogether/server/config/RedisConfig.java
+++ b/server/src/main/java/com/fittogether/server/config/RedisConfig.java
@@ -11,9 +11,11 @@ import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @RequiredArgsConstructor
@@ -27,6 +29,15 @@ public class RedisConfig extends CachingConfigurerSupport {
 
   @Value("${spring.redis.ttl-duration}")
   private Long duration;
+
+  @Bean
+  public RedisTemplate<?, ?> redisTemplate() {
+    RedisTemplate<byte[], byte[]> template = new RedisTemplate<>();
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new StringRedisSerializer());
+    template.setConnectionFactory(lettuceConnectionFactory());
+    return template;
+  }
 
   @Bean
   public LettuceConnectionFactory lettuceConnectionFactory() {


### PR DESCRIPTION
토글로 좋아요, 취소 구현
   -  토글과 캐싱 부분은 낙관락 적용하여 동시성 제어
   - 좋아요가 되어 있다면 db에서 delete하고 좋아요 수 캐싱
   - 좋아요가 되어있지 않다면 db에 값 저장후 좋아요 수 캐싱
   - 좋아요 수의 캐싱된 key가 없다면 db조회해서 좋아요 수를 가져오고
   - key가 있고 그 중 좋아요가 눌린 상태라면 value를 감소,
   - 눌리지 않은 상태라면 value를 증가시킨다
   - @Scheduled를 통해 3분마다 좋아요 수를 db에 업데이트하고 캐시를 삭제한다.

조회수 캐싱
   - 게시글 조회시 조회수가 redis에 캐싱되도록 구현
   - redis에 key가 없다면 db 조회하여 조회수를 가져와 증가시키고 캐싱
   - 없으면 저장된 value값을 증가 시킨다.
   - increment할 때 db에 업데이트하지 않고, Redis에만 count 증가시키고 그 값을 사용
   - 조회 시 redis의 값을 db 값 대신 사용
   - @Scheduled를 통해 3분마다 조회수를 db에 업데이트하고 캐시를 삭제한다.
