### PR TITLE
feat: [user] - 닉네임, 이메일 중복검사 추가

### DIFF
--- a/server/user/src/main/java/com/fittogether/server/user/controller/UserController.java
+++ b/server/user/src/main/java/com/fittogether/server/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.fittogether.server.user.service.UserSignInService;
 import com.fittogether.server.user.service.UserSignUpService;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,6 +26,24 @@ public class UserController {
         return ResponseEntity.ok(
                 signUpService.signUp(form)
         );
+    }
+
+    @GetMapping("/signup/check/nickname")
+    public ResponseEntity<?> checkNickname(@RequestParam("nickname") String nickname) {
+        if (!signUpService.isExistNickname(nickname)) {
+            return ResponseEntity.status(HttpStatus.OK).body("해당 닉네임은 사용 가능합니다.");
+        } else {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("해당 닉네임은 이미 존재합니다.");
+        }
+    }
+
+    @GetMapping("/signup/check/email")
+    public ResponseEntity<?> checkEmail(@RequestParam("email") String email) {
+        if (!signUpService.isExistEmail(email)) {
+            return ResponseEntity.status(HttpStatus.OK).body("해당 이메일은 사용 가능합니다.");
+        } else {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("해당 이메일은 이미 존재합니다.");
+        }
     }
 
     @ApiOperation(value = "로그인", response = String.class)

--- a/server/user/src/main/java/com/fittogether/server/user/exception/UserErrorCode.java
+++ b/server/user/src/main/java/com/fittogether/server/user/exception/UserErrorCode.java
@@ -7,10 +7,6 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode {
-    // 회원가입 중복검사
-    ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
-    ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
-
     // 로그인
     NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "일치하는 회원이 없습니다."),
     NOT_FOR_FITTOGETHER(HttpStatus.BAD_REQUEST, "소셜 로그인으로 다시 로그인해주세요."),

--- a/server/user/src/main/java/com/fittogether/server/user/service/UserSignUpService.java
+++ b/server/user/src/main/java/com/fittogether/server/user/service/UserSignUpService.java
@@ -4,8 +4,6 @@ import com.fittogether.server.user.domain.dto.SignUpForm;
 import com.fittogether.server.user.domain.dto.UserDto;
 import com.fittogether.server.user.domain.model.User;
 import com.fittogether.server.user.domain.repository.UserRepository;
-import com.fittogether.server.user.exception.UserCustomException;
-import com.fittogether.server.user.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,25 +16,26 @@ public class UserSignUpService {
     // 일반 회원가입
     @Transactional
     public UserDto signUp(SignUpForm form) {
-        isExistNickname(form.getNickname());
-        isExistEmail(form.getEmail());
-
         User user = userRepository.save(User.from(form));
 
         return UserDto.from(user);
     }
 
     // 닉네임 중복검사
-    private void isExistNickname(String nickname) {
+    public boolean isExistNickname(String nickname) {
         if (userRepository.existsByNickname(nickname)) {
-            throw new UserCustomException(UserErrorCode.ALREADY_EXIST_NICKNAME);
+            return true;
         }
+
+        return false;
     }
 
     // 이메일 중복검사
-    private void isExistEmail(String email) {
+    public boolean isExistEmail(String email) {
         if (userRepository.existsByEmail(email)) {
-            throw new UserCustomException(UserErrorCode.ALREADY_EXIST_EMAIL);
+            return true;
         }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Changes

- 기존: 회원가입 버튼을 눌렀을 때 닉네임, 이메일 한번에 중복검사 후 진행
- 변경: 회원가입 버튼 누르기 전 닉네임과 이메일 중복검사 후 회원가입 진행되도록

1. 닉네임 중복검사
  - `get` : /users/signup/check/nickname?nickname={nickname}
  - `param` : nickname
  - `return` : 성공시, status.200. 실패시, status:409. (+ messages)
2. 이메일 중복검사
  - `get` : /users/signup/check/email?email={email}
  - `param` : email
  - `return` : 성공시, status.200. 실패시, status:409. (+ messages)
