### PR TITLE
feat : [posts] - 이미지 업로드 구현

### DIFF
--- a/server/posts/src/main/java/com/fittogether/server/posts/controller/ImageUploadController.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/controller/ImageUploadController.java
@@ -1,0 +1,52 @@
+package com.fittogether.server.posts.controller;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+public class ImageUploadController {
+
+  private final AmazonS3Client amazonS3Client;
+
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+
+  @PostMapping("/upload")
+  public ResponseEntity<List<String>> uploadImage(@RequestParam("image") List<MultipartFile> images) {
+    List<String> imageUrls = new ArrayList<>();
+
+    try {
+      for (MultipartFile image : images) {
+        String fileName = image.getOriginalFilename();
+        String fileUrl = "https://" + bucket + "/test" + fileName;
+
+        ObjectMetadata metadata = new ObjectMetadata();
+
+        metadata.setContentType(image.getContentType());
+        metadata.setContentLength(image.getSize());
+        amazonS3Client.putObject(bucket, fileName, image.getInputStream(), metadata);
+
+        imageUrls.add(fileUrl);
+      }
+
+      return ResponseEntity.ok(imageUrls);
+
+    } catch (IOException e) {
+      e.printStackTrace();
+
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+}

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostDto.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostDto.java
@@ -16,7 +16,6 @@ public class PostDto {
   private Long id;
   private String title;
   private String description;
-  private String image;
   private Category category;
   private boolean accessLevel;
   private LocalDateTime createdAt;
@@ -26,7 +25,6 @@ public class PostDto {
         .id(post.getId())
         .title(post.getTitle())
         .description(post.getDescription())
-        .image(post.getImage())
         .category(post.getCategory())
         .accessLevel(post.isAccessLevel())
         .createdAt(LocalDateTime.now())

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostForm.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostForm.java
@@ -15,7 +15,7 @@ public class PostForm {
 
   private String title;
   private String description;
-  private String image;
+  private List<String> images;
   private Category category;
   private boolean accessLevel;
   private List<String> hashtag;

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostInfo.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostInfo.java
@@ -1,6 +1,7 @@
 package com.fittogether.server.posts.domain.dto;
 
 import com.fittogether.server.posts.domain.model.ChildReply;
+import com.fittogether.server.posts.domain.model.Image;
 import com.fittogether.server.posts.domain.model.Post;
 import com.fittogether.server.posts.domain.model.Reply;
 import com.fittogether.server.posts.type.Category;
@@ -22,24 +23,24 @@ public class PostInfo {
   private Category category;
   private String title;
   private String description;
-  private String image;
   private Long likeCount;
   private Long viewCount;
   private Long replyCount;
+  private List<String> images;
   private boolean accessLevel;
   private boolean isLike;
   private List<ReplyDto> replyList;
   private List<ReplyDto> childReplyList;
   private LocalDateTime createdAt;
 
-  public static PostInfo from(Post post, List<Reply> replyList, List<ChildReply> childReplyList, Long totalCount, boolean isLike, Long incrementWatchedCount) {
+  public static PostInfo from(Post post, List<Reply> replyList, List<ChildReply> childReplyList, Long totalCount, boolean isLike, Long incrementWatchedCount, List<Image> images) {
 
     return PostInfo.builder()
         .userId(post.getUser().getUserId())
         .category(post.getCategory())
         .title(post.getTitle())
         .description(post.getDescription())
-        .image(post.getImage())
+        .images(images.stream().map(Image::getImageUrl).collect(Collectors.toList()))
         .likeCount(post.getLikes())
         .viewCount(incrementWatchedCount)
         .replyCount(totalCount)

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyDto.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/ReplyDto.java
@@ -17,6 +17,7 @@ public class ReplyDto {
   private String comment;
   private LocalDateTime createdAt;
   private String userNickname;
+  private String userImage;
   private Long postId;
 
   public static ReplyDto from(Reply reply) {
@@ -25,6 +26,7 @@ public class ReplyDto {
         .comment(reply.getComment())
         .createdAt(LocalDateTime.now())
         .userNickname(reply.getUser().getNickname())
+        .userImage(reply.getUser().getProfilePicture())
         .postId(reply.getPost().getId())
         .build();
   }
@@ -34,6 +36,7 @@ public class ReplyDto {
         .comment(childReply.getComment())
         .createdAt(LocalDateTime.now())
         .userNickname(childReply.getUser().getNickname())
+        .userImage(childReply.getUser().getProfilePicture())
         .postId(childReply.getReply().getPost().getId())
         .replyId(childReply.getReply().getId())
         .build();

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Image.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/model/Image.java
@@ -1,16 +1,13 @@
 package com.fittogether.server.posts.domain.model;
 
-import com.fittogether.server.posts.type.Category;
-import com.fittogether.server.user.domain.model.User;
-import java.time.LocalDateTime;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,26 +20,15 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 @Entity
-public class Post {
-
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = "image_url"))
+public class Image {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @ManyToOne
-  @JoinColumn(name = "user_id")
-  private User user;
+  @JoinColumn(name = "post_id")
+  private Post post;
 
-  private String title;
-  private String description;
-
-  @Enumerated(value = EnumType.STRING)
-  private Category category;
-  private Long likes;
-  private Long watched;
-  private boolean accessLevel;
-
-  private LocalDateTime createdAt;
-  private LocalDateTime modifiedAt;
-
+  private String imageUrl;
 }

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/repository/ImageRepository.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/repository/ImageRepository.java
@@ -1,0 +1,11 @@
+package com.fittogether.server.posts.domain.repository;
+
+import com.fittogether.server.posts.domain.model.Image;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+  Image findByImageUrl(String imageUrl);
+
+  List<Image> findByPostId(Long postId);
+}


### PR DESCRIPTION
List로 이미지를 받아와야 해서 image테이블을 따로 만들었습니다.

파일 업로드 요청 api의 반환으로 aws s3에 이미지를 저장하고 저장된 이미지의 url을 받아옵니다.

게시글 생성시 postForm에 담겨 url이 db에 저장됩니다.

DB에 이미지 url을 저장하기위해 List<String> images를 findByImageUrl을 통해 저장된 이미지가 있으면 그 url 그대로 반환,
없으면 post정보와 함께 저장하도록 구현했습니다.