### PR TITLE
refactor : [posts] - 오류 수정

### DIFF
--- a/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/controller/PostController.java
@@ -78,6 +78,6 @@ public class PostController {
   public ResponseEntity<LikeDto> likePost(@RequestHeader(name = "X-AUTH-TOKEN") String token,
                                           @PathVariable Long postId) {
     return ResponseEntity.ok(LikeDto.from(
-        likeService.likePost(token, postId), likeService.getLikeCountByDB(postId)));
+        likeService.likePost(token, postId), likeService.getLikeCountByRedis(postId)));
   }
 }

--- a/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostInfo.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/domain/dto/PostInfo.java
@@ -38,7 +38,7 @@ public class PostInfo {
 
   public static PostInfo from(Post post, List<Reply> replyList, List<ChildReply> childReplyList,
       Long totalCount, boolean isLike, Long incrementWatchedCount, List<Image> images,
-      List<String> hashtagList) {
+      List<String> hashtagList, Long likeCount) {
 
     return PostInfo.builder()
         .postId(post.getId())
@@ -48,7 +48,7 @@ public class PostInfo {
         .description(post.getDescription())
         .images(images.stream().map(Image::getImageUrl).collect(Collectors.toList()))
         .userImage(post.getUser().getProfilePicture())
-        .likeCount(post.getLikes())
+        .likeCount(likeCount)
         .viewCount(incrementWatchedCount)
         .replyCount(totalCount)
         .accessLevel(post.isAccessLevel())

--- a/server/posts/src/main/java/com/fittogether/server/posts/service/LikeService.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/service/LikeService.java
@@ -54,6 +54,9 @@ public class LikeService {
     return LikeToggle(post, user);
   }
 
+  /**
+   * 좋아요 토글
+   */
   @Lock(LockModeType.OPTIMISTIC)
   private boolean LikeToggle(Post post, User user) {
     boolean isLiked = likeRepository.existsByPostAndUser(post, user);
@@ -74,12 +77,16 @@ public class LikeService {
     return !isLiked;
   }
 
+  /**
+   * 좋아요 캐싱
+   */
   @Transactional
   public void getCachedLikeCount(Long postId, boolean isLiked) {
     String likeCountKey = "postLikeCount::" + postId;
 
     ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
 
+    // 저장된 캐시가 없을 시
     if (valueOperations.get(likeCountKey) == null) {
       Long likeCount = getLikeCountByDB(postId);
       valueOperations.set(likeCountKey, String.valueOf(likeCount));
@@ -92,22 +99,50 @@ public class LikeService {
     }
   }
 
+  /**
+   * 좋아요 캐시 값 가져오기
+   */
+  public Long getLikeCountByRedis(Long postId) {
+    String likeCountKey = "postLikeCount::" + postId;
+
+    ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+    Long likeCount;
+    if (valueOperations.get(likeCountKey) == null) {
+      likeCount = getLikeCountByDB(postId);
+    } else {
+      likeCount = Long.parseLong(valueOperations.get(likeCountKey));
+    }
+    return likeCount;
+  }
+
+  /**
+   * 좋아요 DB에서 가져오기
+   */
   public Long getLikeCountByDB(Long postId) {
     return likeRepository.countByPostId(postId);
   }
 
+  /**
+   * 스케줄링으로 업데이트 호출 및 캐시 삭제
+   */
   @Scheduled(cron = "0 0/3 * * * *")
   public void updateLikeCountByRedis() {
     log.info("DB 좋아요 수 갱신");
     Set<String> keys = redisTemplate.keys("postLikeCount::*");
+
     for (String data : keys) {
       Long postId = Long.parseLong(data.split("::")[1]);
       Long likeCount = Long.parseLong(redisTemplate.opsForValue().get(data));
+
       updateLikeCountDB(postId, likeCount);
       redisTemplate.delete("postLikeCount::" + postId);
     }
   }
 
+  /**
+   * 좋아요 DB 업데이트
+   */
   @Transactional
   public void updateLikeCountDB(Long postId, Long likeCount) {
     Post post = postRepository.findById(postId)

--- a/server/posts/src/main/java/com/fittogether/server/posts/service/PostService.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/service/PostService.java
@@ -57,6 +57,7 @@ public class PostService {
   private final AuthenticationService authenticationService;
   private final ImageService imageService;
   private final ReplyService replyService;
+  private final LikeService likeService;
 
   /**
    * 게시글 작성
@@ -216,8 +217,10 @@ public class PostService {
     Long incrementWatchedCount = incrementWatchedCount(postId);
     Long totalReplyCount = replyService.getTotalReplyCount(postId);
 
+    Long likeCount = likeService.getLikeCountByRedis(postId); // 캐싱된 조회수 가져오기
+
     return PostInfo.from(post, replyList, childReplies, totalReplyCount, isLike,
-        incrementWatchedCount, images, hashtagList);
+        incrementWatchedCount, images, hashtagList, likeCount);
   }
 
 


### PR DESCRIPTION
현재 좋아요가 캐싱을 적용해둔 상태인데
게시글 보기 시 좋아요의 수를 가져오는 곳이 DB였어서 업데이트가 바로바로 안되는 문제

>> DB가아닌 Redis에서 좋아요 수를 가져오도록 변경