### PR TITLE
feat: [user] - 프로필 사진 업로드

### DIFF
--- a/server/user/src/main/java/com/fittogether/server/user/controller/UserInfoController.java
+++ b/server/user/src/main/java/com/fittogether/server/user/controller/UserInfoController.java
@@ -9,6 +9,9 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
@@ -51,4 +54,11 @@ public class UserInfoController {
         );
     }
 
+    @PostMapping("/upload")
+    public ResponseEntity<String> updateProfileImage(@RequestHeader(name = "X-AUTH-TOKEN") String token,
+                                              @RequestParam("image") MultipartFile image) throws IOException {
+        return ResponseEntity.ok(
+                userService.updateProfileImage(token, image)
+        );
+    }
 }


### PR DESCRIPTION
## Changes

1. 프로필 사진 업로드
- `put`: /users/upload?image={image}
- `header`: token
- `requestparam`: MultipartFile image
- `return`: String fileURL
- 내용: S3에 사용자의 프로필 사진을 업로드 하는 URI 추가. 이때 fileName을 "profile_{userId}"로 설정하여 각 사용자의 프로필 사진은 1개만 이용할 수 있도록 설정하였고 새롭게 업로드되는 이미지를 최신으로 반영되도록 구현함.