### PR TITLE
refactor : [posts] - 게시글 검색 및 전체 게시글 조회수 업데이트 수정

### DIFF
--- a/server/posts/src/main/java/com/fittogether/server/posts/service/LikeService.java
+++ b/server/posts/src/main/java/com/fittogether/server/posts/service/LikeService.java
@@ -12,6 +12,7 @@ import com.fittogether.server.user.domain.model.User;
 import com.fittogether.server.user.domain.repository.UserRepository;
 import com.fittogether.server.user.exception.UserCustomException;
 import com.fittogether.server.user.exception.UserErrorCode;
+import java.util.Objects;
 import java.util.Set;
 import javax.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
@@ -111,7 +112,7 @@ public class LikeService {
     if (valueOperations.get(likeCountKey) == null) {
       likeCount = getLikeCountByDB(postId);
     } else {
-      likeCount = Long.parseLong(valueOperations.get(likeCountKey));
+      likeCount = Long.parseLong(Objects.requireNonNull(valueOperations.get(likeCountKey)));
     }
     return likeCount;
   }
@@ -131,13 +132,13 @@ public class LikeService {
     log.info("DB 좋아요 수 갱신");
     Set<String> keys = redisTemplate.keys("postLikeCount::*");
 
-    for (String data : keys) {
+    Objects.requireNonNull(keys).forEach(data -> {
       Long postId = Long.parseLong(data.split("::")[1]);
-      Long likeCount = Long.parseLong(redisTemplate.opsForValue().get(data));
+      Long likeCount = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue().get(data)));
 
       updateLikeCountDB(postId, likeCount);
       redisTemplate.delete("postLikeCount::" + postId);
-    }
+    });
   }
 
   /**


### PR DESCRIPTION
스케줄링 for문 -> steam 변환

게시글 리스트를 볼때 조회수가 캐싱되어 
주기적인 db업데이트가 되는데 리스트나 검색 시 db값을 반환받다보니 바로바로 조회수가 적용이 안되는 문제가 있었습니다.
>>
캐시된 조회수를 반환하는 메서드를 만들어서
그 조회수가 전체 게시글, 게시글 검색 메서드들의 watched에 적용될 수 있도록 변경.