### PR TITLE
Feat: [video] - "Video 조회 시 5개씩 나오도록 page 기능 추가"

### DIFF
--- a/server/video/src/main/java/com/fittogether/server/video/controller/VideoController.java
+++ b/server/video/src/main/java/com/fittogether/server/video/controller/VideoController.java
@@ -1,15 +1,16 @@
 package com.fittogether.server.video.controller;
 
+import com.fittogether.server.video.domain.dto.CursorResult;
 import com.fittogether.server.video.domain.dto.VideoDto;
 import com.fittogether.server.video.service.CrawlingService;
 import com.fittogether.server.video.service.VideoService;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,13 +22,12 @@ public class VideoController {
   private final CrawlingService crawlingService;
 
   @GetMapping("/{keyword}")
-  public ResponseEntity<List<VideoDto>> readYoutubeVideo(
-      @PathVariable(name = "keyword") String keyword
-  ) {
+  public ResponseEntity<CursorResult<VideoDto>> getVideos(
+      @PathVariable(name = "keyword") String keyword,
+      @RequestParam(value = "cursorId", required = false) Long cursorId,
+      @RequestParam(value = "size", required = false, defaultValue = "5") int size) {
 
-    return ResponseEntity.ok(videoService.getVideoByKeyword(keyword).stream()
-        .map(VideoDto::from)
-        .collect(Collectors.toList()));
+    return ResponseEntity.ok(videoService.get(keyword, cursorId, PageRequest.of(0, size)));
   }
 
   @GetMapping("/crawl/running")

--- a/server/video/src/main/java/com/fittogether/server/video/domain/dto/CursorResult.java
+++ b/server/video/src/main/java/com/fittogether/server/video/domain/dto/CursorResult.java
@@ -1,0 +1,21 @@
+package com.fittogether.server.video.domain.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class CursorResult<T> {
+  private List<T> values;
+  private Boolean hasNext;
+  private Long lastId;
+
+  public CursorResult(List<T> values, Boolean hasNext, Long lastId){
+    this.values = values;
+    this.hasNext = hasNext;
+    this.lastId = lastId;
+  }
+}

--- a/server/video/src/main/java/com/fittogether/server/video/domain/dto/VideoPageDto.java
+++ b/server/video/src/main/java/com/fittogether/server/video/domain/dto/VideoPageDto.java
@@ -1,0 +1,33 @@
+package com.fittogether.server.video.domain.dto;
+
+import com.fittogether.server.video.domain.model.Video;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class VideoPageDto {
+
+  private Long id;
+  private String videoId;
+  private String title;
+  private String thumbnail;
+  private String keyword;
+
+  public static VideoPageDto from(Video video){
+    return VideoPageDto.builder()
+        .id(video.getId())
+        .videoId(video.getVideoId())
+        .title(video.getTitle())
+        .thumbnail(video.getThumbnail())
+        .keyword(video.getKeyword())
+        .build();
+  }
+
+}

--- a/server/video/src/main/java/com/fittogether/server/video/domain/repository/VideoRepository.java
+++ b/server/video/src/main/java/com/fittogether/server/video/domain/repository/VideoRepository.java
@@ -1,9 +1,13 @@
 package com.fittogether.server.video.domain.repository;
 
+
+import org.springframework.data.domain.Pageable;
 import com.fittogether.server.video.domain.model.Video;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,6 +17,10 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
 
   Optional<Video> findByVideoId(String youtubeVideoId);
 
-  List<Video> findByKeyword(String keyword);
+  List<Video> findAllByKeywordOrderByIdDesc(String keyword, Pageable page);
+
+  List<Video> findByKeywordAndIdLessThanOrderByIdDesc(String keyword, Long id, Pageable page);
+
+  Boolean existsByIdLessThan(Long id);
 
 }

--- a/server/video/src/main/java/com/fittogether/server/video/service/VideoService.java
+++ b/server/video/src/main/java/com/fittogether/server/video/service/VideoService.java
@@ -6,6 +6,8 @@ import com.fittogether.server.user.domain.model.User;
 import com.fittogether.server.user.domain.repository.UserRepository;
 import com.fittogether.server.user.exception.UserCustomException;
 import com.fittogether.server.user.exception.UserErrorCode;
+import com.fittogether.server.video.domain.dto.CursorResult;
+import com.fittogether.server.video.domain.dto.VideoDto;
 import com.fittogether.server.video.domain.model.Playlist;
 import com.fittogether.server.video.domain.model.PlaylistVideo;
 import com.fittogether.server.video.domain.model.Video;
@@ -15,7 +17,9 @@ import com.fittogether.server.video.domain.repository.VideoRepository;
 import com.fittogether.server.video.exception.VideoCustomException;
 import com.fittogether.server.video.exception.VideoErrorCode;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +33,28 @@ public class VideoService {
   private final VideoRepository videoRepository;
   private final JwtProvider provider;
 
+  public CursorResult<VideoDto> get(String keyword, Long cursorId, Pageable page) {
+    final List<Video> videos = getVideos(keyword, cursorId, page);
+    final Long lastIdOfList = videos.isEmpty() ? null : videos.get(videos.size() - 1).getId();
+
+    Long lastId = videos.get(videos.size() - 1).getId();
+    List<VideoDto> videosDto = videos.stream().map(VideoDto::from).collect(Collectors.toList());
+    return new CursorResult<>(videosDto, hasNext(lastIdOfList), lastId);
+  }
+
+  private List<Video> getVideos(String keyword, Long cursorId, Pageable page) {
+    return cursorId == null ?
+        this.videoRepository.findAllByKeywordOrderByIdDesc(keyword, page) :
+        this.videoRepository.findByKeywordAndIdLessThanOrderByIdDesc(keyword, cursorId, page);
+  }
+
+  private Boolean hasNext(Long id) {
+    if (id == null) {
+      return false;
+    }
+    return this.videoRepository.existsByIdLessThan(id);
+  }
+
   public List<PlaylistVideo> getVideoInPlaylist(String token, String targetName) {
     UserVo userVo = provider.getUserVo(token);
 
@@ -39,14 +65,6 @@ public class VideoService {
         targetName).orElseThrow(() -> new VideoCustomException(VideoErrorCode.NOT_FOUND_PLAYLIST));
 
     return playlistVideoRepository.findByPlaylistId(playlist.getPlaylistId());
-  }
-
-  public List<Video> getVideoByKeyword(String keyword){
-    if(videoRepository.findByKeyword(keyword).isEmpty()){
-      throw new VideoCustomException(VideoErrorCode.NOT_FOUND_KEYWORD);
-    }
-
-    return videoRepository.findByKeyword(keyword);
   }
 
   @Transactional


### PR DESCRIPTION
Changes
---
* `get` : /video/{keyword}?cursorId={cursorId}&size={size} -> keyword에 해당하는 영상 중에서 size 수만큼 잘라서 보여줌, cursorId에 응답으로 받은 마지막 영상의 id를 입력하면 그 다음 영상부터 size 수 만큼 나옴
* 맨 처음에는 cursorId를 모르기 떄문에 안넣고 요청해도 됨, ex) /video/{keyword}?size={size}
* size값은 5가 기본값이므로 안넣고 요청해도 됨, ex) /video/{keyword}?cursorId=29