### PR TITLE
Feat [video] - "playlist에서 최근에 저장한 동영상 5개씩 나오도록 설정"

### DIFF
--- a/server/video/src/main/java/com/fittogether/server/video/controller/VideoController.java
+++ b/server/video/src/main/java/com/fittogether/server/video/controller/VideoController.java
@@ -29,7 +29,7 @@ public class VideoController {
     if(cursorId == -1){
       cursorId = null;
     }
-    return ResponseEntity.ok(videoService.get(keyword, cursorId, PageRequest.of(0, size)));
+    return ResponseEntity.ok(videoService.getFromVideos(keyword, cursorId, PageRequest.of(0, size)));
   }
 
   @GetMapping("/crawl/running")

--- a/server/video/src/main/java/com/fittogether/server/video/domain/form/VideoForm.java
+++ b/server/video/src/main/java/com/fittogether/server/video/domain/form/VideoForm.java
@@ -1,0 +1,16 @@
+package com.fittogether.server.video.domain.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VideoForm {
+
+  String title;
+
+}

--- a/server/video/src/main/java/com/fittogether/server/video/domain/repository/PlaylistVideoRepository.java
+++ b/server/video/src/main/java/com/fittogether/server/video/domain/repository/PlaylistVideoRepository.java
@@ -1,8 +1,10 @@
 package com.fittogether.server.video.domain.repository;
 
 import com.fittogether.server.video.domain.model.PlaylistVideo;
+import com.fittogether.server.video.domain.model.Video;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,6 +20,12 @@ public interface PlaylistVideoRepository extends JpaRepository<PlaylistVideo, Lo
   void deleteAllByPlaylist_PlaylistId(Long playlistId);
 
   void deleteByPlaylist_PlaylistIdAndVideo_Id(Long playlistId, Long videoId);
+
+  List<PlaylistVideo> findAllByPlaylist_PlaylistIdOrderByModifiedAtDesc(Long playlistId, Pageable page);
+
+  List<PlaylistVideo> findByPlaylist_PlaylistIdAndIdLessThanOrderByIdDesc(Long playlistId, Long id, Pageable page);
+
+  Boolean existsByIdLessThan(Long id);
 
   // playlistId로 playlist 와 video 받아옴
   @Query("select pv from PlaylistVideo pv "


### PR DESCRIPTION
Changes
---
* `get` : /playlist/{name}?cursorId={cursorId}&size={size}
* 기존 카테고리 별 영상 조회와 같이 playlist에 저장한 동영상도 5개씩 나오도록 함
* 기존 카테고리 별 영상 조회와 같이 최초 요청 시 cursorId에 -1 값 넣으면 됨, size는 기본 값 5이므로 변경사항 없으면 생략 가능
* 기존에 playlist에 동영상 추가 시 RequestBody를 String으로 보낸 것에서 VideoForm으로 변경